### PR TITLE
Allow parsing diffs that have no patch or binary declaration

### DIFF
--- a/src/diff.pegjs
+++ b/src/diff.pegjs
@@ -22,18 +22,14 @@
         binary: !!binary
       }
     } else if (file_modes.old_mode && file_modes.new_mode) {
-      if (patch || binary) {
-        return {
-          newPath: header.file_name,
-          oldPath: header.file_name,
-          oldMode: file_modes.old_mode,
-          newMode: file_modes.new_mode,
-          hunks: patch ? patch.hunks : [],
-          status: 'modified',
-          binary: !!binary
-        }
-      } else {
-        throw new Error('patch or binary expected')
+      return {
+        newPath: header.file_name,
+        oldPath: header.file_name,
+        oldMode: file_modes.old_mode,
+        newMode: file_modes.new_mode,
+        hunks: patch ? patch.hunks : [],
+        status: 'modified',
+        binary: !!binary
       }
     } else {
       throw new Error('file modes missing')

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -520,3 +520,25 @@ exports.testBinaryFiles = function(test) {
   ])
   test.done()
 }
+
+exports.testNoPatch = function(test) {
+  var str = dedent`
+  diff --git file.txt file.txt
+  old mode 100644
+  new mode 100755
+  `
+
+  const output = diff.parse(str)
+  assert.deepEqual(output, [
+    {
+      oldPath: 'file.txt',
+      newPath: 'file.txt',
+      oldMode: '100644',
+      newMode: '100755',
+      status: 'modified',
+      hunks: [],
+      binary: false
+    },
+  ])
+  test.done()
+}


### PR DESCRIPTION
Prerequisite for https://github.com/atom/github/pull/1275

Diffs for file mode changes have no patch associated with them
```
diff --git a/file1.txt b/file1.txt
old mode 100644
new mode 100755
```

Previously we threw an error if a diff had no patch or binary declaration. This PR removes that restriction.