### PR TITLE
Handle merge conflict entries with empty patches

### DIFF
--- a/src/diff.pegjs
+++ b/src/diff.pegjs
@@ -77,7 +77,7 @@ unmerged_path
   = '* Unmerged path ' path:TEXT NL { return postProcessMergeConflictDiff(path) }
 
 patch
-  = header:patch_header hunks:hunk+ { return {hunks} }
+  = header:patch_header hunks:hunk* { return {hunks} }
 
 patch_header
   = '--- ' old_file_name:TEXT NL '+++ ' new_file_name:TEXT NL { return {old_file_name, new_file_name} }

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -542,3 +542,23 @@ exports.testNoPatch = function(test) {
   ])
   test.done()
 }
+
+exports.testMergeConflictNoPatch = function(test) {
+  var str = dedent`
+  diff --cc file-0.txt
+  index 1fbec74,3bfc451..0000000
+  --- file-0.txt
+  +++ file-0.txt
+  `
+
+  const output = diff.parse(str)
+  assert.deepEqual(output, [
+    {
+      filePath: 'file-0.txt',
+      status: 'unmerged',
+      hunks: [],
+      binary: false
+    }
+  ])
+  test.done()
+}


### PR DESCRIPTION
It turns out that git merge conflict entries can contain empty patches:

```diff
diff --cc file-0.txt
index 1fbec74,3bfc451..0000000
--- file-0.txt
+++ file-0.txt
```

This adds a test case that captures this and changes the grammar to parse these without throwing an error.

This should fix the root cause of https://github.com/atom/github/issues/1409. :sparkles: