### PR TITLE
Implement handling renames and copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ parse(diffStr)
     ]
   }
 ```
+
+If the diff includes a similarity index line (from a detected copy or rename), the `similarity` property will be set, and will be a number.

--- a/src/diff.pegjs
+++ b/src/diff.pegjs
@@ -82,8 +82,8 @@ binary_merge_conflict_diff
   = path:merge_conflict_header_line index_line binary_declaration { return postProcessMergeConflictDiff(path, undefined, true) }
 
 rename_or_copy_diff
-  = header:rename_or_copy_diff_header_line similarity:similarity_index old_file:rename_copy_from new_file:rename_copy_to {
-    return postProcessSimilarityDiff(old_file.operation, similarity, old_file.file, new_file.file)
+  = header:rename_or_copy_diff_header_line similarity:similarity_index copy_from:rename_copy_from copy_to:rename_copy_to {
+    return postProcessSimilarityDiff(copy_from.operation, similarity, copy_from.file, copy_to.file)
   }
 
 merge_conflict_diff

--- a/src/diff.pegjs
+++ b/src/diff.pegjs
@@ -79,7 +79,7 @@ binary_merge_conflict_diff
   = path:merge_conflict_header_line index_line binary_declaration { return postProcessMergeConflictDiff(path, undefined, true) }
 
 rename_or_copy_diff
-  = header:rename_or_copy_diff_header_line similarity:similarity_index copy_from:rename_copy_from copy_to:rename_copy_to {
+  = rename_or_copy_diff_header_line similarity:similarity_index copy_from:rename_copy_from copy_to:rename_copy_to {
     return postProcessSimilarityDiff(copy_from.operation, similarity, copy_from.file, copy_to.file)
   }
 

--- a/src/diff.pegjs
+++ b/src/diff.pegjs
@@ -48,12 +48,9 @@
     return {
       oldPath: old_file,
       newPath: new_file,
-      oldMode: null,
-      newMode: null,
       hunks: [],
       status: rename_or_copy === 'copy' ? 'copied' : 'renamed',
       similarity: similarity_index,
-      binary: null
     }
   }
 }

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -560,22 +560,16 @@ exports.testRenameCopy = function(test) {
     {
       oldPath: 'old/file.png',
       newPath: 'new/file.png',
-      oldMode: null,
-      newMode: null,
       status: 'renamed',
       similarity: 90,
       hunks: [],
-      binary: null
     },
     {
       oldPath: 'copy/file.png',
       newPath: 'copy/file2.png',
-      oldMode: null,
-      newMode: null,
       status: 'copied',
       similarity: 100,
       hunks: [],
-      binary: null
     },
   ])
   test.done()

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -543,6 +543,44 @@ exports.testNoPatch = function(test) {
   test.done()
 }
 
+exports.testRenameCopy = function(test) {
+  var str = dedent`
+  diff --git old/file.png new/file.png
+  similarity index 90%
+  rename from old/file.png
+  rename to new/file.png
+  diff --git copy/file.png copy/file2.png
+  similarity index 100%
+  copy from copy/file.png
+  copy to copy/file2.png
+  `
+
+  const output = diff.parse(str)
+  assert.deepEqual(output, [
+    {
+      oldPath: 'old/file.png',
+      newPath: 'new/file.png',
+      oldMode: null,
+      newMode: null,
+      status: 'renamed',
+      similarity: 90,
+      hunks: [],
+      binary: null
+    },
+    {
+      oldPath: 'copy/file.png',
+      newPath: 'copy/file2.png',
+      oldMode: null,
+      newMode: null,
+      status: 'copied',
+      similarity: 100,
+      hunks: [],
+      binary: null
+    },
+  ])
+  test.done()
+}
+
 exports.testMergeConflictNoPatch = function(test) {
   var str = dedent`
   diff --cc file-0.txt

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -575,6 +575,47 @@ exports.testRenameCopy = function(test) {
   test.done()
 }
 
+exports.testRenameWithChangedLinesAndModeChange = function(test) {
+  var str = dedent`
+  diff --git file.txt rename-file.txt
+  old mode 100644
+  new mode 100755
+  similarity index 76%
+  rename from file.txt
+  rename to rename-file.txt
+  index 471a7b8..3e32ec2
+  --- file.txt
+  +++ rename-file.txt
+  @@ -1,4 +1,5 @@
+   foo
+   bar
+   baz
+  +qux
+
+  `;
+
+  const output = diff.parse(str)
+  assert.deepEqual(output, [
+    {
+      oldPath: "file.txt",
+      newPath: "rename-file.txt",
+      oldMode: "100644",
+      newMode: "100755",
+      status: "renamed",
+      similarity: 76,
+      hunks: [{
+        oldStartLine: 1,
+        oldLineCount: 4,
+        newStartLine: 1,
+        newLineCount: 5,
+        heading: '',
+        lines: [' foo', ' bar', ' baz', '+qux']
+      }]
+    }
+  ]);
+  test.done()
+}
+
 exports.testMergeConflictNoPatch = function(test) {
   var str = dedent`
   diff --cc file-0.txt


### PR DESCRIPTION
This is an attempt to fix https://github.com/kuychaco/what-the-diff/issues/10.

This technically works, but I don't love it for a couple reasons:

* The `similarity` field only shows up if the parser detects that the diff includes a rename or copy. We could include this in *all* return values and just set it to `null`, but the field doesn't make sense outside of the context of a copy.
* The `binary` field is usually `true` or `false`, but in this case, we don't actually know if the file is binary or not, so I opted to set this to `null`.
* Both modes are set to `null`, which typically can be used to determine if a file is created or deleted, but like `binary`, don't make sense in this context.

One option is to return different concrete and documented types for the various kinds of diffs, but that feels like a semver-major change.

If folks have 💭s, please feel free to share!

/cc @kuychaco, @kytwb, @smashwilson, @annthurium