### PR TITLE
Limit files published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
     "diff",
     "parser"
   ],
+  "files": [
+    "index.js",
+    "lib/**/*",
+    "src/**/*",
+    "test/**/*"
+  ],
   "author": "Katrina Uychaco <kuychaco@gmail.com>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Fixes #13 

```
$ npm pack

📦  what-the-diff@0.4.0
=== Tarball Contents ===
638B   package.json
132B   index.js
1.1kB  LICENSE
901B   README.md
3B     lib/.gitkeep
48.0kB lib/parser.js
4.6kB  src/diff.pegjs
11.0kB test/diff.test.js
=== Tarball Details ===
name:          what-the-diff
version:       0.4.0
filename:      what-the-diff-0.4.0.tgz
package size:  9.9 kB
unpacked size: 66.3 kB
shasum:        8642e2d88ce9dee4b61302753f235b794024e0b3
integrity:     sha512-iwNZ2Zbv9CFR7[...]tw8QZdvQWWpVg==
total files:   8

what-the-diff-0.4.0.tgz
```