### PR TITLE
fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ what-the-diff is available via npm
 ## Usage
 
 ```javascript
-let parse = require('what-the-diff')
+let {parse} = require('what-the-diff')
 
 var str = `diff --git file.txt file.txt
 index 83db48f..bf269f4 100644


### PR DESCRIPTION
`parse` needs to be destructured out of the module's exports