### PR TITLE
fix: optional patch header before binary diffs

### DIFF
--- a/src/diff.pegjs
+++ b/src/diff.pegjs
@@ -72,7 +72,7 @@ diff
   / regular_diff
 
 binary_diff
-  = header:diff_header_line file_modes:file_mode_section? binary_declaration { return postProcessDiff(header, file_modes, undefined, true) }
+  = header:diff_header_line file_modes:file_mode_section? patch_header? binary_declaration { return postProcessDiff(header, file_modes, undefined, true) }
 
 binary_declaration
   = 'Binary files ' TEXT NL

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -486,6 +486,12 @@ exports.testBinaryFiles = function(test) {
     deleted file mode 100644
     index e26b70a..0000000
     Binary files three.gif and /dev/null differ
+    diff --git a/cat.png b/cat.png
+    new file mode 100644
+    index 0000000..8b8dc61
+    --- /dev/null
+    +++ b/cat.png
+    Binary files differ
   `
 
   const output = diff.parse(str)
@@ -517,6 +523,15 @@ exports.testBinaryFiles = function(test) {
       hunks: [],
       binary: true
     },
+    {
+      oldPath: null,
+      newPath: 'b/cat.png',
+      hunks: [],
+      oldMode: null,
+      newMode: '100644',
+      status: 'added',
+      binary: true
+    }
   ])
   test.done()
 }


### PR DESCRIPTION
Some diff tools include a patch header when diffing between binary files, e.g. https://chromium.googlesource.com/chromium/src/+/74.0.3724.8..74.0.3729.5

```diff
diff --git a/chrome/app/theme/default_100_percent/common/origami/avatar_cat.png b/chrome/app/theme/default_100_percent/common/origami/avatar_cat.png
new file mode 100644
index 0000000..8b8dc61
--- /dev/null
+++ b/chrome/app/theme/default_100_percent/common/origami/avatar_cat.png
Binary files differ
```